### PR TITLE
Cherry-pick fix from original repo which was missed when moving the repo.

### DIFF
--- a/precheckin.sh
+++ b/precheckin.sh
@@ -21,7 +21,11 @@ SPEC=${SPEC%.tmpl}
 PATHS=""
 while read -r path || [[ -n "$path" ]]; do
     echo "Text read from file: $path"
-    PATHS="${PATHS} $path"
+    if [ ! -d ../$path ]; then
+        echo "skipping non existent path: $path"
+    else
+        PATHS="${PATHS} $path"
+    fi
 done < <(cat additional-source.paths dhs/source.paths 2>/dev/null)
 
 # Trim the last space


### PR DESCRIPTION
[dhs] skip non-existent folders. JB#40476

For example kernel might be named kernel-3.10 instead
of kernel which can be dealt with in additional-source.paths

Signed-off-by: Franz-Josef Haider <franz.haider@jolla.com>