### PR TITLE
dhs: Immediately fail Android builds on OBS if a command fails

### DIFF
--- a/droid-hal-source.inc
+++ b/droid-hal-source.inc
@@ -158,7 +158,13 @@ cat <<"EOF" > droid-make
 # ubu-chroot with the correct lunch setup
 # It is only intended to run in the OBS builders
 
-exec ubu-chroot -r /srv/mer/sdks/ubu "%{?pre_actions}; source build/envsetup.sh; lunch %{?lunch_device}%{!?lunch_device:%{device}}%{?device_variant}; make $*"
+# We can check if we have new or old ubu-chroot by checking if it has the -V  option
+# added with this version.
+if ubu-chroot -V ; then
+   bash="bash -c"
+fi
+
+exec ubu-chroot -r /srv/mer/sdks/ubu ${bash} "set -o errexit; %{?pre_actions}; source build/envsetup.sh; lunch %{?lunch_device}%{!?lunch_device:%{device}}%{?device_variant}; make $*"
 EOF
 
 %{?post_build_actions}


### PR DESCRIPTION
Run the Android build commands with set -e/errexit so that in case one of
them fails the shell directly exits instead of silently continuing.