### PR TITLE
Fixes needed for Android 13 base

### DIFF
--- a/droid-hal-source.inc
+++ b/droid-hal-source.inc
@@ -186,7 +186,9 @@ for tree in %dhs_trees ; do
 done
 
 # Top level makefile
+if [ -f %android_root/Makefile ]; then
 mv %android_root/Makefile $RPM_BUILD_ROOT/home/abuild/src/droid/
+fi
 
 # Install the droid-make helper
 mkdir -p $RPM_BUILD_ROOT/usr/bin

--- a/precheckin.sh
+++ b/precheckin.sh
@@ -29,7 +29,7 @@ fi
 PATHS=""
 while read -r path || [[ -n "$path" ]]; do
     echo "Text read from file: $path"
-    if [ ! -d ../$path ]; then
+    if [ ! -d ../$path ] && [ ! -f ../$path ]; then
         echo "skipping non existent path: $path"
     else
         PATHS="${PATHS} $path"
@@ -41,7 +41,8 @@ PATHS=${PATHS% }
 
 REQLIST=""
 for path in $PATHS; do
-    REQLIST="${REQLIST} %{dhs_feature}-${path//\//-}"
+    REQLIST="${REQLIST} %{dhs_feature}-${path//[\/.]/-}"
+    REQLIST="${REQLIST,,}"
 done
 
 cat <<EOF > package-section
@@ -130,7 +131,8 @@ EOF
 
 for path in $PATHS
 do
-    pkg=${path//\//-}
+    pkg=${path//[\/.]/-}
+    pkg=${pkg,,}
 
     cat <<EOF >> package-section
 %package $pkg

--- a/precheckin.sh
+++ b/precheckin.sh
@@ -70,6 +70,7 @@ Summary: Utilities for using the syspart source for droid-side code building.
 This package is hardcoded for %{device}%{?device_variant}
 It is only meant for use in the OBS.
 
+%if 0%{!?dhs_no_makefile:1}
 %package dhs-makefile
 Provides: %{dhs_feature}-dhs-makefile
 Group:  System
@@ -79,12 +80,16 @@ Summary: Top level makefile to be used for droid-side code building
 %description dhs-makefile
 Top level makefile to be used for droid-side code building
 It is only meant for use in the OBS.
+%endif
 
 %package dhs-rootdir
 Provides: %{dhs_feature}-dhs-rootdir
 Group:  System
 AutoReqProv: no
-Requires: %{dhs_feature}-dhs-utils %{dhs_feature}-dhs-makefile
+Requires: %{dhs_feature}-dhs-utils
+%if 0%{!?dhs_no_makefile:1}
+Requires: %{dhs_feature}-dhs-makefile
+%endif
 Requires(post): /bin/sh
 Summary: Top level source files for the device src tree to be used for droid-side code building
 %description dhs-rootdir
@@ -102,6 +107,7 @@ cat <<EOF >files-section
 %defattr(755,root,root,-)
 /usr/bin/droid-make
 
+%if 0%{!?dhs_no_makefile:1}
 %post dhs-makefile
 # The abuild user is not setup at post time so we use the numeric id
 chown 399:399 /home/abuild/src
@@ -111,6 +117,7 @@ chown 399:399 /home/abuild/src/droid/Makefile
 %files dhs-makefile
 %defattr(-,root,root,-)
 /home/abuild/src/droid/Makefile
+%endif
 
 %post dhs-rootdir
 # The abuild user is not setup at post time so we use the numeric id
@@ -130,7 +137,10 @@ do
 Provides: %{dhs_feature}-$pkg
 Group:  System
 AutoReqProv: no
-Requires: %{dhs_feature}-dhs-utils %{dhs_feature}-dhs-makefile
+Requires: %{dhs_feature}-dhs-utils
+%if 0%{!?dhs_no_makefile:1}
+Requires: %{dhs_feature}-dhs-makefile
+%endif
 Requires(post): /bin/sh
 Summary: Source for the $pkg src tree to be used for droid-side code building
 %description $pkg


### PR DESCRIPTION
Make Makefile optional. Allow packaging single files.